### PR TITLE
Reader implements io.ReaderAt and io.Seeker when the metadata is not gzipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Go vendoring
+vendor/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/YourFin/binappend
+
+go 1.14
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
This is useful in case someone stores a zip file (not gzip) and wants to unzip it directly.